### PR TITLE
Bump rustc version to nightly-2016-02-22 r=ferjm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-    - nightly-2016-02-13
+    - nightly-2016-02-22
 env:
     global:
         - RUST_TEST_THREADS=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ rand = "0.3.14"
 [dev-dependencies]
 iron-test = "*"
 stainless = "0.1.4"
-clippy = "0.0.41"
+clippy = "0.0.44"

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ The main modules that this crate exposes are:
 Currently v1.8.x nightly is required
 ```bash
 $ rustc -V
-rustc 1.8.0-nightly (fae516277 2016-02-13)
+rustc 1.8.0-nightly (c92e910c1 2016-02-21)
 ```
 It's recommended that you use [`multirust`](https://github.com/brson/multirust) to install and switch between versions of Rust.
 ```bash
-$ multirust override nightly-2016-02-13
+$ multirust override nightly-2016-02-22
 ```
 ### Exposing the HTTP API
 ```rust


### PR DESCRIPTION
Following new version update in foxbox, here is the pr to keep same version for rustc and libraries used.

@ferjm r?
