### PR TITLE
fix markdown heading rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ You should fork the main repo and create pull requests against feature branches
 of your fork. If you need some guidance with this see:
  - https://guides.github.com/introduction/flow/
  - http://scottchacon.com/2011/08/31/github-flow.html
+
 ### Setup
 ```bash
 $ git clone git@github.com:<username>/users.git


### PR DESCRIPTION
This fixes the setup heading not rendering properly.

![screenshot from 2016-03-07 13-36-41](https://cloud.githubusercontent.com/assets/979929/13584084/b50e0b38-e469-11e5-8d69-5b05ae4f83b8.png)

I also noticed that there isn't very much spacing in between the different sections, which I think makes for more comfortable reading when looking at the plain text anyways.

I'm happy to update that, but didn't want there to be a ton of white space changes in this PR. Let me know.
