### PR TITLE
User display names can be empty (i.e. invitations)

### DIFF
--- a/src/users_db.rs
+++ b/src/users_db.rs
@@ -164,10 +164,6 @@ impl UserBuilder {
     }
 
     pub fn name(mut self, name: String) -> Self {
-        if name.is_empty() {
-            self.error = Some(UserBuilderError::Name);
-            return self;
-        }
         self.name = escape(&name);
         self
     }


### PR DESCRIPTION
We are not allowing logins with display names anymore, only with emails, so users can have empty display names values.
